### PR TITLE
Feat/gh1 ipsec peers

### DIFF
--- a/lib/junos_ipsec_summary
+++ b/lib/junos_ipsec_summary
@@ -60,12 +60,12 @@ def main():
     results = {"ike": {}, "ipsec": {}}
     try:
         sa_info = dev.rpc.get_ike_security_associations_information()
-        base = 'multi-routing-engine-item/\
-                ike-security-associations-information'
+        base = 'multi-routing-engine-item/' \
+               'ike-security-associations-information'
         sa_info = sa_info.find(base)
     except Exception as err:
-        msg = 'unable to get phase 1 sa info on {}: \
-               {}'.format(m_args['host'], str(err))
+        msg = 'unable to get phase 1 sa info on {}: ' \
+              '{}'.format(m_args['host'], str(err))
         module.fail_json(msg=msg)
         return
     for sa in sa_info:
@@ -83,12 +83,12 @@ def main():
                                          "state": state}
     try:
         sa_info = dev.rpc.get_security_associations_information(detail=True)
-        base = 'multi-routing-engine-item/\
-                ipsec-security-associations-information'
-        sa_info = sa_info.find(p)
+        base = 'multi-routing-engine-item/' \
+               'ipsec-security-associations-information'
+        sa_info = sa_info.find(base)
     except Exception as err:
-        msg = "can't get phase 2 sa info for {}:\
-               {}".format(m_args['host'], str(err))
+        msg = "can't get phase 2 sa info for {}: " \
+              "{}".format(m_args['host'], str(err))
         module.fail_json(msg=msg)
         return
     for sa in sa_info:
@@ -100,14 +100,14 @@ def main():
         if m_args['peers'] == 'all':
             results['ipsec'][index] = {"index": index,
                                        "address": peer,
-                                       "name": vpn_name,
+                                       "name": vpn,
                                        "state": state,
                                        "interface": interface}
         else:
             if peer in m_args['peers']:
                 results['ipsec'][index] = {"index": index,
                                            "address": peer,
-                                           "name": vpn_name,
+                                           "name": vpn,
                                            "state": state,
                                            "interface": interface}
     dev.close()


### PR DESCRIPTION
closes #1.  removes requirement for the `peers` option, and defaults to `all`, retrieving and displaying all SAs.
