### PR TITLE
Added catch for RpcError in lldp grabber.

### DIFF
--- a/lib/junos_lldp
+++ b/lib/junos_lldp
@@ -33,6 +33,7 @@ from jnpr.junos import Device
 from jnpr.junos.factory.table import Table
 from jnpr.junos.factory.view import View
 from jnpr.junos.op.lldp import LLDPNeighborTable
+from jnpr.junos.exception import RpcError
 import json
 
 class TableJSONEncoder(json.JSONEncoder):
@@ -73,6 +74,10 @@ def main():
         lldp = LLDPNeighborTable(dev)
         lldp.get()
         lldp = json.loads(json.dumps(lldp, cls=TableJSONEncoder))
+    except RpcError as err:
+        dev.close()
+        module.fail_json(msg=err.rpc_error['message'])
+        return
     except Exception as err:
         dev.close()
         module.fail_json(msg=err)

--- a/lib/junos_lldp
+++ b/lib/junos_lldp
@@ -75,8 +75,22 @@ def main():
         lldp.get()
         lldp = json.loads(json.dumps(lldp, cls=TableJSONEncoder))
     except RpcError as err:
+        ## Ok, so this is really weird.  If I issue the below command (print err),
+        ## then 'rpc_error' magically appears as an attribute of err.
+        ## But without it, I have to dig through the XML to find the error message.
+        ## WTF?
+        #print err
+        msg = ''
+        rpc_error = getattr(err,'rpc_error',None)
+        if rpc_error is None:
+            ## 2003 called.  They want their XML back.
+            errmsg = err.rsp.find('error-message')
+            if errmsg is not None:
+                msg = errmsg.text.strip()
+        else:
+            msg = rpc_error.get('message','')
         dev.close()
-        module.fail_json(msg=err.rpc_error['message'])
+        module.fail_json(msg=msg)
         return
     except Exception as err:
         dev.close()


### PR DESCRIPTION
I discovered this when my playbook ended in a traceback while I was testing against an Olive VM. I'm sure the RpcError needs to be caught in other modules as well and on some level may benefit from catching it inside of some sort of abstraction that can be applied to all junos modules.

Also, I'm not sure if 'master' is the right place for this pull request, but wasn't sure where else to do it. I am open to suggestions.
